### PR TITLE
Feature #11 목록페이지를 구현한다

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -13,7 +13,7 @@ const Card = forwardRef<HTMLDivElement, { memory: MemoryType }>(({ memory }, ref
     </S.CardComponentWrapper>
   )
 })
-Card.displayName = 'Input'
+Card.displayName = 'Card'
 
 export default Card
 

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,0 +1,51 @@
+import { forwardRef } from 'react'
+import styled from '@emotion/styled'
+
+import { MemoryType } from '@/pages/memory-list'
+
+const Card = forwardRef<HTMLDivElement, { memory: MemoryType }>(({ memory }, ref) => {
+  return (
+    <S.CardComponentWrapper ref={ref} backgroundImage={memory.backgroundImage}>
+      <S.CardComponentTitle>{memory.createdAt}</S.CardComponentTitle>
+      <S.CardComponentDesc>{memory.text}</S.CardComponentDesc>
+      {/* 임시 */}
+      <p style={{ marginTop: '24px' }}>memoryId: {memory.id}</p>
+    </S.CardComponentWrapper>
+  )
+})
+Card.displayName = 'Input'
+
+export default Card
+
+const S = {
+  CardComponentWrapper: styled.div<{ backgroundImage: MemoryType['backgroundImage'] }>`
+    box-sizing: border-box;
+
+    height: 185px;
+    margin: 11px 35px;
+    padding: 22px;
+    border-radius: 16px;
+    color: #fff;
+    opacity: 1;
+    cursor: pointer;
+    &:hover {
+      opacity: 0.8;
+    }
+    object-fit: cover;
+    background-image: ${({ backgroundImage }) => `url(${backgroundImage})`};
+
+    /* 임시 */
+    background: #b6e6b0;
+  `,
+  CardComponentTitle: styled.h2`
+    font-size: 24px;
+    font-weight: 800;
+  `,
+  CardComponentDesc: styled.p`
+    margin-top: 32px;
+    font-size: 12px;
+    font-weight: 300;
+    line-height: 18px;
+    letter-spacing: -0.3px;
+  `,
+}

--- a/pages/memory-list/index.tsx
+++ b/pages/memory-list/index.tsx
@@ -1,3 +1,144 @@
-export default function MemoryList() {
-  return <h1>Memory List</h1>
+import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import styled from '@emotion/styled'
+
+import Card from '@/components/Card'
+
+/**mock data */
+const MockMemoryType = (currentPage: number) => {
+  return {
+    data: [
+      {
+        id: currentPage,
+        backgroundImage: '',
+        youtubeUrl: '',
+        text: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+        createdAt: 'July 23',
+        deletedAt: 'July 23',
+      },
+      {
+        id: currentPage,
+        backgroundImage: '',
+        youtubeUrl: '',
+        text: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+        createdAt: 'July 23',
+        deletedAt: 'July 23',
+      },
+    ],
+    currentPage: currentPage,
+  }
+}
+
+// memory types
+export type MemoryType = {
+  id: number
+  backgroundImage: string
+  youtubeUrl: string
+  text: string
+  createdAt: string
+  deletedAt: string
+}
+
+export type MemoryListType = {
+  data: MemoryType[]
+  currentPage: number
+}
+
+// server data fetching
+export const getServerSideProps: GetServerSideProps<{
+  initMemoryList: MemoryListType
+}> = async () => {
+  /** fetch data */
+  // const getMemoryListRes = await fetch(`https://-?memoryList=1`)
+  // const initMemoryList = await getMemoryListRes.json()
+
+  // mock data
+  const initMemoryList = MockMemoryType(1)
+  return { props: { initMemoryList } }
+}
+
+export default function MemoryList({ initMemoryList }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const [memoryList, setMemoryList] = useState<MemoryListType>(initMemoryList)
+
+  const targetRef = useRef<HTMLDivElement>(null)
+  const mockNumber = useRef(2)
+
+  const handleIntersect = useCallback(
+    ([entry]: IntersectionObserverEntry[]) => {
+      if (entry.isIntersecting) {
+        /** fetch data */
+        // const getMemoryList = axios.get<MemoryListType>(`https://-?memoryList=${memoryList.currentPage}`)
+        // getMemoryList.then((res) => {
+        //   if (res.status !== 200) return
+
+        //   setMemoryList((prev) => {
+        //     if (prev && prev.currentPage === 1) return
+        //     else
+        //       return {
+        //         ...prev,
+        //         data: [...prev.data, ...res.data.data],
+        //         currentPage: res.data.currentPage,
+        //       }
+        //   })
+        // })
+
+        /** mock data */
+        setMemoryList((prev) => {
+          return {
+            ...prev,
+            data: [...prev.data, ...MockMemoryType(mockNumber.current).data],
+            currentPage: MockMemoryType(mockNumber.current).currentPage,
+          }
+        })
+        mockNumber.current++
+      }
+    },
+    [targetRef.current]
+  )
+
+  /** control observer */
+  useEffect(() => {
+    const observer = new IntersectionObserver(handleIntersect, {
+      threshold: 0.9,
+      root: null,
+    })
+
+    targetRef.current && observer.observe(targetRef.current)
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [handleIntersect, targetRef.current])
+
+  return (
+    <S.Wrapper>
+      <S.Title>My Palace</S.Title>
+      {memoryList?.data.map((memory, index) => (
+        <Card key={index} memory={memory} ref={targetRef} />
+      ))}
+    </S.Wrapper>
+  )
+}
+
+const S = {
+  Wrapper: styled.div`
+    /* 임시 */
+    margin: 800px auto;
+    width: 414px;
+  `,
+  Title: styled.h1`
+    color: #000;
+    text-align: center;
+    font-size: 24px;
+    font-family: Inter;
+    line-height: 32px;
+    letter-spacing: -0.6px;
+    text-align: left;
+    padding: 26px 47px;
+  `,
+  CardWrapper: styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  `,
 }


### PR DESCRIPTION
### 관련 문서
#11 

### 변경사항:
**음악 재생을 구현하지 않았지만 작성한 type이 작업시 도움될 수 있을 것 같아 미리 PR 올립니다!**
- Card 컴포넌트를 작성했습니다.
- 목록에서 쓰일 type을 지정했습니다.
```typescript
/* pages/memory-list/index.tsx */

// memory types
export type MemoryType = {
  id: number
  backgroundImage: string
  youtubeUrl: string
  text: string
  createdAt: string
  deletedAt: string
}

export type MemoryListType = {
  data: MemoryType[]
  currentPage: number
}
```
- intersection observer를 이용해 무한스크롤기능을 구현했습니다.
- api가 나오지 않아서 임시로 mock data를 선언해서 구현했습니다.

### 확인할 목록:
- [ ] 모바일 환경으로 작업하려면 _app.tsx에서 width를 설정하는 작업을 해야할 것 같은데 다들 어떻게 생각하시나요? 
일단 저는 임시로 아래와 같이 스타일을 지정해줬습니다!
```css
/* pages/memory-list/index.tsx */
Wrapper: styled.div`
    /* 임시 */
    margin: 800px auto;
    width: 414px;
`,
```
- [ ] 타입스크립트 타입 지정시 type vs interface 중 어떤걸 사용할지 통일하는게 좋을까요?
