### PR TITLE
Feature #43 videoId 변경 함수 동작 수정

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -19,7 +19,10 @@ const Card = forwardRef<HTMLDivElement, CardProps>(({ memory }, ref) => {
   const { isOpen, handleCloseModal, handleOpenModal } = useControlModal()
 
   const convertedTitle = createdAtToTitleDate(memory.createdAt)
-  const slicedVideoId = makeYouTubeVideoId(memory.videoId)
+  const slicedVideoId =
+    !memory.videoId.includes('youtu.be/') && !memory.videoId.includes('youtube.com')
+      ? memory.videoId
+      : makeYouTubeVideoId(memory.videoId)
 
   return (
     <>
@@ -35,9 +38,11 @@ const Card = forwardRef<HTMLDivElement, CardProps>(({ memory }, ref) => {
         </Modal>
       )}
       <S.CardComponentContainer ref={ref} backgroundImage={memory.backgroundImage}>
-        <S.CardComponentPlayerWrapper>
-          <CardPlayButton videoId={slicedVideoId} />
-        </S.CardComponentPlayerWrapper>
+        {!!memory.videoId && (
+          <S.CardComponentPlayerWrapper>
+            <CardPlayButton videoId={slicedVideoId} />
+          </S.CardComponentPlayerWrapper>
+        )}
         <S.CardComponentWrapper onClick={() => handleOpenModal()}>
           <S.CardComponentTitle>{convertedTitle}</S.CardComponentTitle>
           <S.CardComponentDesc>{memory.text}</S.CardComponentDesc>

--- a/lib/utils/makeYouTubeVideoId.ts
+++ b/lib/utils/makeYouTubeVideoId.ts
@@ -1,11 +1,11 @@
-const sliceYouTubeUrlType = (youtubeUrl: string) => youtubeUrl.slice()
-
 const isUrlContainsVParam = (youtubeUrl: string) => {
   const regex = /\?v=/
   return regex.test(youtubeUrl)
 }
 
 const makeYouTubeVideoId = (youtubeUrl: string) => {
+  if (!youtubeUrl.includes('youtu.be/') && !youtubeUrl.includes('youtube.com')) return ''
+
   if (isUrlContainsVParam(youtubeUrl)) return new URL(youtubeUrl).searchParams.get('v') as string
   else return youtubeUrl.slice(youtubeUrl.lastIndexOf('/') + 1)
 }

--- a/pages/memory-list/index.tsx
+++ b/pages/memory-list/index.tsx
@@ -33,7 +33,7 @@ export type MemoryType = {
   id: number
   backgroundImage: string
   text: string
-  videoId: string
+  videoId?: string
   createdAt: string
   deletedAt?: string
 }
@@ -122,8 +122,6 @@ export default function MemoryList({ initMemoryList }: InferGetServerSidePropsTy
 const S = {
   Wrapper: styled.div`
     padding: 24px 0;
-    /* 임시 */
-    margin-top: 800px;
   `,
   Title: styled.h1`
     color: #000;

--- a/pages/memory-list/index.tsx
+++ b/pages/memory-list/index.tsx
@@ -33,7 +33,7 @@ export type MemoryType = {
   id: number
   backgroundImage: string
   text: string
-  videoId?: string
+  videoId: string
   createdAt: string
   deletedAt?: string
 }


### PR DESCRIPTION
### 관련 문서
Closes #43 


### 변경사항:
- memory list 페이지 margin 800px 제거
- makeYouTubeVideoId함수 url에 youtube가 없다면 빈 string을 반환하도록 수정
- Card에서 받아올 때 videoId에 youtube 포함여부에 따라 slicedVideoId 분기 처리

### 확인할 목록:

