### PR TITLE
Feature #79 메인페이지 로딩 상태 처리한다

### DIFF
--- a/components/common/Suspense/CustomSuspense.tsx
+++ b/components/common/Suspense/CustomSuspense.tsx
@@ -1,16 +1,21 @@
-import { useEffect, useState } from 'react'
-import { CustomSuspenseProps } from '../../../lib/types/mainTypes'
+import { useEffect, useState, ReactNode } from 'react'
+
+export interface CustomSuspenseProps {
+  fallback: ReactNode
+  maxDuration?: number
+  children: ReactNode
+}
 
 export default function CustomSuspense({ fallback, maxDuration, children }: CustomSuspenseProps) {
-  const [loadingDone, setLoadingDone] = useState(false)
+  const [isLoadingDone, setIsLoadingDone] = useState(false)
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      setLoadingDone(true)
+      setIsLoadingDone(true)
     }, maxDuration)
 
     return () => clearTimeout(timer)
   }, [maxDuration])
 
-  return <>{loadingDone ? children : fallback}</>
+  return <>{isLoadingDone ? children : fallback}</>
 }

--- a/components/common/Suspense/CustomSuspense.tsx
+++ b/components/common/Suspense/CustomSuspense.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, ReactNode } from 'react'
 
-export interface CustomSuspenseProps {
+interface CustomSuspenseProps {
   fallback: ReactNode
   maxDuration?: number
   children: ReactNode

--- a/components/common/Suspense/CustomSuspense.tsx
+++ b/components/common/Suspense/CustomSuspense.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react'
+import { CustomSuspenseProps } from '../../../lib/types/mainTypes'
+
+export default function CustomSuspense({ fallback, maxDuration, children }: CustomSuspenseProps) {
+  const [loadingDone, setLoadingDone] = useState(false)
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setLoadingDone(true)
+    }, maxDuration)
+
+    return () => clearTimeout(timer)
+  }, [maxDuration])
+
+  return <>{loadingDone ? children : fallback}</>
+}

--- a/lib/types/mainTypes.ts
+++ b/lib/types/mainTypes.ts
@@ -1,7 +1,0 @@
-import { ReactNode } from 'react'
-
-export interface CustomSuspenseProps {
-  fallback: ReactNode
-  maxDuration?: number
-  children: ReactNode
-}

--- a/lib/types/mainTypes.ts
+++ b/lib/types/mainTypes.ts
@@ -1,0 +1,7 @@
+import { ReactNode } from 'react'
+
+export interface CustomSuspenseProps {
+  fallback: ReactNode
+  maxDuration?: number
+  children: ReactNode
+}

--- a/pages/main/index.tsx
+++ b/pages/main/index.tsx
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled'
+
+import CustomSuspense from '../../components/common/Suspense/CustomSuspense'
+import CubeLoader from '@/components/common/Loader/CubeLoader'
+
+export default function Main() {
+  return (
+    <>
+      <CustomSuspense
+        fallback={
+          <LoaderContainer>
+            <CubeLoader />
+          </LoaderContainer>
+        }
+        maxDuration={5500}
+      >
+        <div>3D 모델 영역</div>
+      </CustomSuspense>
+    </>
+  )
+}
+
+const LoaderContainer = styled.div`
+  width: 100%;
+  max-width: 600px;
+  height: 100vh;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`

--- a/pages/main/index.tsx
+++ b/pages/main/index.tsx
@@ -24,7 +24,6 @@ const LoaderContainer = styled.div`
   width: 100%;
   max-width: 600px;
   height: 100vh;
-
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## 관련 문서
Closes #79

## 변경사항:
- Suspense와 fallback를 사용해 비동기적으로 로딩 상태를 처리하였습니다.
- 로딩시, CubeLoader가 보이도록 했습니다.
- Suspense만 사용시, CubeLoader가 거의 보이지 않았습니다. 그래서 의도적으로 5.5초 동안은 CubeLoader가 보이도록 CustomSuspense컴포넌트를 만들어 적용했습니다.

## 확인할 목록:
- 코드 레벨 확인
