### PR TITLE
chore: color token을 실제 색상과 통일 시킴

### DIFF
--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -4,7 +4,7 @@ const colors = {
     bright: '#4DA3FF',
     light: '#8FC4FF',
     strong: '#003D80',
-    heavy: '#003D80',
+    heavy: '#00254D',
     disable: '#D0DDEBCC',
   },
   text: {

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,11 +1,11 @@
 const colors = {
   primary: {
     normal: '#007AFF',
-    bright: '#3395FF',
-    light: '#66AFFF',
+    bright: '#4DA3FF',
+    light: '#8FC4FF',
     strong: '#2559F4',
-    heavy: '#1A4DE5',
-    disable: '#D0DDEB',
+    heavy: '#003D80',
+    disable: '#D0DDEBCC',
   },
   text: {
     strong: '#000000',
@@ -25,7 +25,7 @@ const colors = {
   },
   line: {
     normal: '#6D7179',
-    alternative: '#F4F4F5',
+    alternative: '#BCBCC2',
   },
 }
 const typography = {

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -3,7 +3,7 @@ const colors = {
     normal: '#007AFF',
     bright: '#4DA3FF',
     light: '#8FC4FF',
-    strong: '#2559F4',
+    strong: '#003D80',
     heavy: '#003D80',
     disable: '#D0DDEBCC',
   },


### PR DESCRIPTION
## 관련 문서
https://www.figma.com/file/lvfSe6ZCDeAcm3VRonzrrV/mind-palace_modified-(share-1014)?type=design&node-id=287-953&mode=design&t=NzM9QvK4NnEOs6OS-0

Closes #97 

## 변경사항:
피그마 내의 UI의 색상 코드와 color token 색상 코드가 상이하게 적용 되어있는 것을 통일 시킨다.

## 확인할 목록:
피그마 내 UI 내의 색상 코드 중, UI 색상으로 적용되었는지 확인